### PR TITLE
Fix table header scope attribute

### DIFF
--- a/ShineBlazor.Components/KeyValueTableRow.razor
+++ b/ShineBlazor.Components/KeyValueTableRow.razor
@@ -1,11 +1,11 @@
 <tr class="@Class" style="@Style">
     @if (MergeColumns)
     {
-        <th scrope="row" colspan="2">@Key@ChildContent</th>
+        <th scope="row" colspan="2">@Key@ChildContent</th>
     }
     else
     {
-        <th scrope="row">@Key</th>
+        <th scope="row">@Key</th>
         <td>
             @ChildContent
         </td>


### PR DESCRIPTION
## Summary
- fix a typo in KeyValueTableRow component header attribute

## Testing
- `dotnet build ShineBlazorComponents.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1b2f74648332afc98679b86c9e6d