### PR TITLE
Fix flex shrink class in CssClassBuilder

### DIFF
--- a/ShineBlazor.Components/Base/CssClassBuilder.cs
+++ b/ShineBlazor.Components/Base/CssClassBuilder.cs
@@ -255,7 +255,7 @@ namespace ShineBlazor.Components.Base
                     _classes.Add($"flex-grow-{(flexGrow.Value ? "1" : "0")}");
 
                 if (flexShrink.HasValue)
-                    _classes.Add($"flex-shrink{(flexShrink.Value ? "1" : "0")}");
+                    _classes.Add($"flex-shrink-{(flexShrink.Value ? "1" : "0")}");
 
             return this;
         }


### PR DESCRIPTION
## Summary
- correct the `flex-shrink` class format in `CssClassBuilder`

## Testing
- `dotnet build ShineBlazorComponents.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1b6981688332a8cef28b9caedaf2