### PR TITLE
Add unit tests for CssClassBuilder flex behavior

### DIFF
--- a/ShineBlazor.Components.Tests/CssClassBuilderFlexTests.cs
+++ b/ShineBlazor.Components.Tests/CssClassBuilderFlexTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Reflection;
+using ShineBlazor.Components.Base;
+using Xunit;
+
+namespace ShineBlazor.Components.Tests;
+
+public class CssClassBuilderFlexTests
+{
+    private static object CreateEnum(string typeName, string value)
+    {
+        var asm = typeof(CssClassBuilder).Assembly;
+        var type = asm.GetType(typeName, throwOnError: true)!;
+        return Enum.Parse(type, value);
+    }
+
+    private static string BuildFlexClasses(bool row, uint gap, string alignItems, string alignSelf, string alignContent,
+        string justifyContent, string wrap, bool flexFill, bool? flexGrow, bool? flexShrink)
+    {
+        var builder = CssClassBuilder.Create(null);
+        var method = typeof(CssClassBuilder).GetMethod("WithFlex")!;
+        object alignItemsEnum = CreateEnum("ShineBlazor.Components.Base.Enumerations.FlexAlign", alignItems);
+        object alignSelfEnum = CreateEnum("ShineBlazor.Components.Base.Enumerations.FlexAlign", alignSelf);
+        object alignContentEnum = CreateEnum("ShineBlazor.Components.Base.Enumerations.FlexContent", alignContent);
+        object justifyContentEnum = CreateEnum("ShineBlazor.Components.Base.Enumerations.FlexContent", justifyContent);
+        object wrapEnum = CreateEnum("ShineBlazor.Components.Base.Enumerations.FlexWrap", wrap);
+        method.Invoke(builder, new object[] { row, gap, alignItemsEnum, alignSelfEnum, alignContentEnum, justifyContentEnum, wrapEnum, flexFill, flexGrow, flexShrink });
+        return builder.Build();
+    }
+
+    [Fact]
+    public void FlexShrink_WithHyphen()
+    {
+        var classes = BuildFlexClasses(true, 3, "Start", "Start", "Start", "Start", "Wrap", false, null, true);
+        Assert.Contains("flex-shrink-1", classes);
+    }
+
+    [Fact]
+    public void FlexOptions_PopulateClasses()
+    {
+        var classes = BuildFlexClasses(false, 2, "Center", "Stretch", "Between", "End", "Wrap", true, true, false);
+        Assert.Contains("d-flex", classes);
+        Assert.Contains("flex-column", classes);
+        Assert.Contains("gap-2", classes);
+        Assert.Contains("align-content-between", classes);
+        Assert.Contains("align-items-center", classes);
+        Assert.Contains("align-self-stretch", classes);
+        Assert.Contains("justify-content-end", classes);
+        Assert.Contains("flex-wrap", classes);
+        Assert.Contains("flex-fill", classes);
+        Assert.Contains("flex-grow-1", classes);
+        Assert.Contains("flex-shrink-0", classes);
+    }
+}

--- a/ShineBlazor.Components.Tests/ShineBlazor.Components.Tests.csproj
+++ b/ShineBlazor.Components.Tests/ShineBlazor.Components.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ShineBlazor.Components\ShineBlazor.Components.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ShineBlazorComponents.sln
+++ b/ShineBlazorComponents.sln
@@ -14,6 +14,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShineBlazor.Components.Demo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shine.Generator", "Shine.Generator\Shine.Generator.csproj", "{7DE840A6-F534-484C-82FD-3342A36581DA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShineBlazor.Components.Tests", "ShineBlazor.Components.Tests\ShineBlazor.Components.Tests.csproj", "{6A0851D8-BBA9-4602-9A05-AB4043615724}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -29,10 +31,14 @@ Global
 		{214DB40C-69C4-4E3E-92D2-F5FE22E9D065}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{214DB40C-69C4-4E3E-92D2-F5FE22E9D065}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7DE840A6-F534-484C-82FD-3342A36581DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7DE840A6-F534-484C-82FD-3342A36581DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7DE840A6-F534-484C-82FD-3342A36581DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7DE840A6-F534-484C-82FD-3342A36581DA}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+               {7DE840A6-F534-484C-82FD-3342A36581DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+               {7DE840A6-F534-484C-82FD-3342A36581DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+               {7DE840A6-F534-484C-82FD-3342A36581DA}.Release|Any CPU.Build.0 = Release|Any CPU
+                {6A0851D8-BBA9-4602-9A05-AB4043615724}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {6A0851D8-BBA9-4602-9A05-AB4043615724}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {6A0851D8-BBA9-4602-9A05-AB4043615724}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {6A0851D8-BBA9-4602-9A05-AB4043615724}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add xUnit test project for ShineBlazor.Components
- verify flex-shrink class uses a hyphen and other flex options add expected classes
- include test project in solution

## Testing
- `dotnet test ShineBlazor.Components.Tests/ShineBlazor.Components.Tests.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1b7f684c8332ab5d134d519732c1